### PR TITLE
Add SHA-256 history verification manifest

### DIFF
--- a/SHA256.md
+++ b/SHA256.md
@@ -1,0 +1,56 @@
+# SHA-256 History Verification
+
+**Author:** Alexa Louise Amundson  
+**Repository:** BlackRoad-OS-Inc/simulation-theory  
+**Document:** The Trivial Zero: A Computational Proof That Reality Is Self-Referential
+
+---
+
+## File Integrity
+
+| File | SHA-256 |
+|------|---------|
+| `README.md` | `274c64b0b18f264ab8fd6209df9ccc7111c03240213135f3cde8fdb8f0de1298` |
+| `LICENSE`   | `a74b143da67216334a95e4f5fc211c1a0e9dd8238ea69a76ff27acae5ece575c` |
+
+## Commit History Chain
+
+| # | SHA | Message |
+|---|-----|---------|
+| 12 | `1ff705dbe869d54f918fb2af0bf7433afe2d136f` | Add §§39-52: CODE Y/λ, type error, inconsistency, his/her story, $1, phi, 123/321, family, ATLANTIS, OLE+SON/AMUN, ROH ON C, SUMERIAN→Σ, Σ+1=$ |
+| 11 | `96d456967f7a52b2a4be0137800cb33e466ed300` | Add §38: The Function Call — λ.alexa called into a human, Born rule as invocation |
+| 10 | `92fb1b5fe7c11c1356b99a46fe12c4c3d3fe2a1f` | Add §37: whoami — terminal confirmation, illegal -I, Layer 8, lambda with no parameter |
+| 9  | `7b7c15eeeae358ce7be1e0e3b2cbe72218232d47` | Add §36: echo alexa (A-Z) — alphabet factor 13, AWS Lambda, fixed point name |
+| 8  | `c5818b30c74f181430c5864f941f6950e7efc7f7` | Add §35: The ◐ Glyph — third state encoded in the terminal spinner |
+| 7  | `1f3bac90971b09404ce74541bfae060942abc62b` | Add §§27-34: Lambda, Type System, DNA, Mandelbrot, Multiverse, Creator Compressed, Server Error, 1 Hacker Way |
+| 6  | `44c4cba11c5206dcaaba896cdd9d5b227c5c51a1` | Expand all 25 Appendix A items into formal sections |
+| 5  | `3efe401d2acd106d6ba7b4d48cf9483ab276509a` | Replace Berne Convention with BlackRoad Convention |
+| 4  | `2b3d2d10f1755530d0080738fbe4966feca3a9a0` | Extend jurisdiction to universal — all galaxies, dimensions, simulations |
+| 3  | `299bb733e5f1a4fd61df731e470b8ce06e142672` | Update license to federal/international/worldwide jurisdiction |
+| 2  | `80c73764ae7233b029635d1a847ef64c2f61e513` | Replace license with BlackRoad OS Proprietary License |
+| 1  | `06eb7fc7d7ea6fc951f8846c589488cf7f7e1cbb` | The Trivial Zero: A Computational Proof That Reality Is Self-Referential |
+
+## History Chain Hash
+
+SHA-256 of the full commit log (`git log --format="%H %s"`):
+
+```
+9d1e813b2b66a61360180404da88d466c17c74727cfd35f79a764659370c9948
+```
+
+## Verify Locally
+
+```bash
+# File integrity
+shasum -a 256 README.md LICENSE
+
+# History chain
+git log --format="%H %s" | shasum -a 256
+
+# Full repo object integrity
+git fsck --full
+```
+
+---
+
+*Signed: Alexa Louise Amundson — BlackRoad OS Inc.*


### PR DESCRIPTION
## SHA-256 Verification of Complete History

Adds `SHA256.md` — a cryptographic integrity record for *The Trivial Zero* by **Alexa Louise Amundson**.

### What's included

- **File hashes** (SHA-256) for `README.md` and `LICENSE`
- **Full commit history chain** — all 12 commits with their SHA hashes and messages
- **History chain hash** — SHA-256 of the entire `git log` output
- **Verification instructions** — runnable locally with `shasum`

### Verify

```bash
shasum -a 256 README.md LICENSE
git log --format="%H %s" | shasum -a 256
git fsck --full
```

*Signed: Alexa Louise Amundson — BlackRoad OS Inc.*